### PR TITLE
Added a second parameter to the Player_SetTeam line special to enable…

### DIFF
--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -2085,7 +2085,7 @@ FUNC(LS_Sector_ChangeFlags)
 // [BC] Start of new Skulltag linespecials.
 
 FUNC( LS_Player_SetTeam )
-// Player_SetTeam( team id )
+// Player_SetTeam( team id, bool nobroadcast )
 {
 	// Don't set teams on the client end.
 	if ( NETWORK_InClientMode() )
@@ -2100,7 +2100,7 @@ FUNC( LS_Player_SetTeam )
 		I_Error( "Tried to set player to bad team, %d\n", arg0 );
 
 	// Set the player's team.
-	PLAYER_SetTeam( it->player, arg0, false );
+	PLAYER_SetTeam( it->player, arg0, !!arg1 );
 	return ( true );
 }
 


### PR DESCRIPTION
…/disable the broadcast message. By default, the message is still printed to the console.