### PR TITLE
made sdl default and took out alsa as its broken in linux

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1514,10 +1514,10 @@ OptionString SoundOutputsWindows
 
 OptionString SoundOutputsUnix
 {
+	"SDL",			"SDL"
 	"Default",		"Default"
 	"OSS",			"OSS"
-	"ALSA",			"ALSA"
-	"SDL",			"SDL"
+	//"ALSA",			"ALSA"
 	"ESD",			"ESD"
 	"PulseAudio",	"PulseAudio"
 	"No sound",		"No sound"


### PR DESCRIPTION
Tested in Ubuntu 20.04 LTS on a laptop and confirmed working   with a new config.