### PR TITLE
Build a network compatible q-zandronum.pk3 when building on linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+wadsrc*/static/**/**.txt eol=crlf
+wadsrc*/static/**/*.fp eol=crlf
+wadsrc*/static/**/*.vp eol=crlf
+wadsrc*/static/**/*.z eol=crlf
+wadsrc*/static/**/*.enu eol=crlf
+wadsrc*/static/**/*.fr eol=crlf
+wadsrc*/static/**/*.ita eol=crlf
+wadsrc*/static/**/*.ptb eol=crlf
+wadsrc*/static/**/*.z eol=crlf
+wadsrc*/static/**/*.za eol=crlf
+wadsrc*/static/**/*.bat eol=crlf
+wadsrc*/static/**/*.ps eol=crlf
+wadsrc*/static/**/*.i eol=crlf


### PR DESCRIPTION
The usual configuration of git on linux will check out wadsrc with LF line endings in the text files, but your released q-zandronum.pk3 (presumably windows built or deliberately set to CRLF for engine reasons) has CRLF line endings. This causes auth errors connecting to a server that uses the released q-zandronum.pk3.

This patch causes git to check out text files in wadsrc/static/ with CRLF regardless of platform. Unfortunately, I couldn't find a way to instruct git to use specified line endings in a specific directory only when it would otherwise have detected a text file, so I've had to either specify all text files by file extension or all binaries by file extension. Another way to do it would be to include a "make" step that set line endings with unix2dos or similar. Still, the method I've given here at least works.