### PR TITLE
fixed another GCC warning (from zandronum)

### DIFF
--- a/GeoIP/CMakeLists.txt
+++ b/GeoIP/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required( VERSION 2.4 )
+include( CheckFunctionExists )
+
+if( NOT WIN32 )
+  CHECK_FUNCTION_EXISTS( gettimeofday GETTIMEOFDAY_EXISTS )
+  if( GETTIMEOFDAY_EXISTS )
+    add_definitions( -DHAVE_GETTIMEOFDAY=1 )
+  endif( GETTIMEOFDAY_EXISTS )
+endif( NOT WIN32 )
 
 add_library( GeoIP GeoIP.c )
 


### PR DESCRIPTION
This is just a fix for `gettimeofday` to work for non win32 systems.