### PR TITLE
Make APROP_MeleeRange work with SetActorProperty

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4526,6 +4526,11 @@ void P_DoSetActorProperty (AActor *actor, int property, int value)
 		actor->reactiontime = value;
 		break;
 
+	// [Binary] Properly set MeleeRange.
+	case APROP_MeleeRange:
+		actor->meleerange = value;
+		break;
+
 	case APROP_ViewHeight:
 		if (playerActor)
 		{


### PR DESCRIPTION
Basically the same issue as the one I made for Zandronum: https://zandronum.com/tracker/view.php?id=4182