### PR TITLE
ACS lump reading fixes

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -63,6 +63,7 @@
 #include "gstrings.h"
 #include "w_wad.h"
 #include "s_sound.h"
+#include "p_acs.h"
 #include "v_video.h"
 #include "intermission/intermission.h"
 #include "f_wipe.h"

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2451,6 +2451,11 @@ static void D_DoomInit()
 
 	atterm (C_DeinitConsole);
 
+	// [AK] When Zandronum closes, any open lump handles in ACS that mods
+	// forgot to close must be cleared before any resources are deleted.
+	atterm( ACS_ClearLumpHandles );
+
+
 	gamestate = GS_STARTUP;
 
 	// Determine if we're going to be a server, client, or local player.

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -1030,6 +1030,10 @@ void P_ClearACSVars(bool alsoglobal)
 		// [BB] When the global vars are cleared, our query handles surely shouldn't
 		// be needed anymore. So clear them in case mods forgot to do so.
 		g_dbQueries.clear();
+
+		// [AK] Also clear any open lump handles that mods forgot to close when
+		// clearing global variables, as these aren't needed anymore either.
+		ACS_ClearLumpHandles();
 	}
 	else
 	{

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -8329,6 +8329,8 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 					lumpNum = Wads.CheckNumForName( name );
 				}
 
+				ACSLumpHandles[lumpNum].refCount++;
+
 				if(ACSLumpHandles.CheckKey( args[0] ) != NULL)
 					return lumpNum;
 
@@ -8564,7 +8566,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 
 				ACSLumpHandles[args[0]].refCount--;
 
-				if(ACSLumpHandles[args[0]].refCount <= 0)
+				if(ACSLumpHandles[args[0]].refCount == 0)
 					ACSLumpHandles.Remove( args[0] );
 
 				return 0;

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -13173,6 +13173,12 @@ CCMD(acsprofile)
 	ShowProfileData(FuncProfiles, limit, sorter, true);
 }
 
+//*****************************************************************************
+//
+void ACS_ClearLumpHandles( void )
+{
+	ACSLumpHandles.Clear( );
+}
 
 //*****************************************************************************
 //

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -8333,6 +8333,9 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 					lumpNum = Wads.CheckNumForName( name );
 				}
 
+				if(lumpNum == -1)
+					return -1;
+
 				ACSLumpHandles[lumpNum].refCount++;
 
 				if(ACSLumpHandles.CheckKey( args[0] ) != NULL)

--- a/src/p_acs.h
+++ b/src/p_acs.h
@@ -1190,6 +1190,7 @@ FArchive &operator<< (FArchive &arc, acsdefered_t *&defer);
 //*****************************************************************************
 //	PROTOTYPES
 
+void	ACS_ClearLumpHandles( void ); // [AK]
 bool	ACS_IsCalledFromConsoleCommand( void );
 bool	ACS_IsScriptClientSide( int script );
 bool	ACS_IsScriptClientSide( const ScriptPtr *pScriptData );


### PR DESCRIPTION
Backported all fixes done to the feature in Zandronum 3.2, and added some new ones Q-Zandronum needed. The most recent Brutal Doom build can now run correctly in Q-Zandronum.